### PR TITLE
Fix: replace `only_with_esp_idf` with `only_on_esp32` to fix #16

### DIFF
--- a/esphome/components/uapbridge_esp/__init__.py
+++ b/esphome/components/uapbridge_esp/__init__.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(UAPBridge_esp),
         }
-    ).add_extra(cv.only_with_esp_idf)
+    ).add_extra(cv.only_on_esp32)
 )
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(


### PR DESCRIPTION
`only_with_esp_idf` was deprecated in ESPHome 2026.6 since the Arduino library is now based on ESP-IDF.

Fixes #16.